### PR TITLE
Relax `base` dependency.

### DIFF
--- a/diagrams-gtk.cabal
+++ b/diagrams-gtk.cabal
@@ -21,7 +21,7 @@ source-repository head
 
 library
   exposed-modules:     Diagrams.Backend.Gtk
-  build-depends:       base >= 4.2 && < 4.10,
+  build-depends:       base >= 4.2 && < 4.11,
                        diagrams-lib >= 1.3 && < 1.5,
                        diagrams-cairo >= 1.3 && < 1.5,
                        gtk >= 0.12.0 && < 0.15,


### PR DESCRIPTION
Tested with GHC-8.2.1, works fine.