### PR TITLE
Works with GHC 8.6.5, NixOS top of tree package set

### DIFF
--- a/diagrams-gtk.cabal
+++ b/diagrams-gtk.cabal
@@ -12,7 +12,7 @@ copyright:           John Lato
 category:            Graphics
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.2
+tested-with:         GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.2, GHC == 8.6.5
 extra-source-files:  CHANGES.markdown, README.markdown
 
 source-repository head
@@ -21,10 +21,10 @@ source-repository head
 
 library
   exposed-modules:     Diagrams.Backend.Gtk
-  build-depends:       base >= 4.2 && < 4.12,
+  build-depends:       base == 4.*,
                        diagrams-lib >= 1.3 && < 1.5,
                        diagrams-cairo >= 1.3 && < 1.5,
-                       gtk >= 0.12.0 && < 0.15,
+                       gtk >= 0.12.0 && < 0.16,
                        cairo >= 0.12.4 && < 0.14
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
- GTK itself depends on `base == 4.*`, I guess we can be be less
  restrictive, too.

- Tested to work with GTK 0.15.3, so bump the version as well.

- Adjust tested-with field.